### PR TITLE
feature: Add conda recipe for keyrings.artifacts package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,9 +21,6 @@ __pycache__/*
 .idea
 .vscode
 .env
-templates/**
-!templates/**/*.ipynb
-!templates/**/*.tex
 
 # Pytest
 .coverage
@@ -38,3 +35,4 @@ coverage.xml
 *.eggs/
 .installed.cfg
 *.egg-info
+dist/**

--- a/pixi.lock
+++ b/pixi.lock
@@ -1507,9 +1507,9 @@ packages:
   requires_python: '>=3.8'
 - kind: pypi
   name: keyrings-artifacts
-  version: 0.4.0
+  version: 0.4.1
   path: .
-  sha256: 2e0dfa25dacfdbcd49d25f7ad76be3478544c0d859a4913c75daafa66bdda30c
+  sha256: a8411a06bc1eea911496b63a733c420ce101a8d1ebd702499d6f632dc0d3333a
   requires_dist:
   - azure-identity>=1.17.1
   - keyring>=16.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,6 @@ dev = { features = ["dev"], solve-group = "default" }
 [tool.pixi.tasks]
 post-install = "pre-commit install"
 
-
 [tool.pixi.feature.dev.tasks.test]
 # Run tests with pytest and generate a coverage report in XML format
 cmd = "pytest -s -v --cov"
@@ -129,7 +128,7 @@ outputs = ["dist/*.whl", "dist/*.tar.gz"]
 [tool.pixi.feature.dev.tasks.recipe]
 # Generate a conda recipe using grayskull
 # Usage: pixi run -e dev recipe
-cmd = "pixi exec grayskull pypi --strict-conda-forge keyrings.artifacts"
+cmd = "pixi exec grayskull pypi --strict-conda-forge --use-v1-format keyrings.artifacts"
 cwd = "recipe"
 
 [tool.pixi.feature.dev.tasks.release]

--- a/recipe/keyrings.artifacts/recipe.yaml
+++ b/recipe/keyrings.artifacts/recipe.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+
+context:
+  name: keyrings.artifacts
+  version: 0.4.1
+
+package:
+  name: ${{ name|lower }}
+  version: ${{ version }}
+
+source:
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/keyrings_artifacts-${{ version }}.tar.gz
+  sha256: 356ea7fe3dd6af432ec2cd2cd4b6bc30f89eebd5ba0900a1b0142fe9e3b4a585
+
+build:
+  number: 0
+  noarch: python
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+
+requirements:
+  host:
+    - python >=3.7
+    - hatchling
+    - pip
+  run:
+    - python >=3.7
+    - keyring >=16.0
+    - requests >=2.20.0
+    - azure-identity >=1.17.1
+    - keyrings.alt >=5.0.2,<6
+    - pycryptodomex >=3.20.0,<4
+
+tests:
+  - python:
+      imports:
+        - keyrings.artifacts
+  - requirements:
+      run:
+        - pip
+    script:
+      - pip check
+
+about:
+  summary: Keyring backend, that automatically retrieves credentials for Azure Artifacts.
+  license: MIT
+  license_file: LICENSE
+
+extra:
+  recipe-maintainers:
+    - jslorrma


### PR DESCRIPTION
### Description

The package contribution guide (https://conda-forge.org/docs/maintainer/adding_pkgs/) was followed together with grayskull to generate the package recipe. Recipe generation is added as `Pixi task` using `--use-v1-format` option to return a recipe file in the V1 format, which is compatible with rattler-build.

By following these steps, the `keyrings.artifacts` package should soon be available from the conda-forge channel.


Solves #2 